### PR TITLE
Added code to generate function to check if the FSM is in reset state

### DIFF
--- a/src/FSML2CCompiler.h
+++ b/src/FSML2CCompiler.h
@@ -68,6 +68,7 @@ private:
 	std::string Translate_ResetFunction();
 	std::string Translate_ExecFunction();
 	std::string Translate_IsInFinalStateFunction();
+	std::string Translate_IsInResetStateFunction();
 	std::string TranslateTransition(FSMState & starting_state, FSMTransition & t);
 
 	const std::string kStaticCKeyword_ = "static";


### PR DESCRIPTION
This PR adds generation of code to check if the FSM is in the reset state.

The code for this new functionality is like the one for the end state function but it checks if the current state is an end state. 
Being the code very similar, the chances of new bugs being introduced is minimized.